### PR TITLE
Implement env-based detection and scheduler scoring

### DIFF
--- a/agents/agent/agent.go
+++ b/agents/agent/agent.go
@@ -78,16 +78,37 @@ func (a *Agent) ProbeAndLabel(ctx context.Context) error {
 
 // detectGPU populates the label map with GPU-related features.
 func (a *Agent) detectGPU(labels map[string]string) {
-	// Placeholder: In a real implementation, this would shell out to tools
-	// like `lspci`, `nvidia-smi`, or `rocm-smi`.
-	labels[a.labelPrefix+"gpu.vendor"] = "NVIDIA"
-	labels[a.labelPrefix+"gpu.vram"] = "24Gi"
-	labels[a.labelPrefix+"gpu.arch"] = "sm_89"
-	labels[a.labelPrefix+"gpu.int4"] = "true"
+	vendor := os.Getenv("GPU_VENDOR")
+	if vendor == "" {
+		vendor = "NVIDIA"
+	}
+
+	vram := os.Getenv("GPU_VRAM")
+	if vram == "" {
+		vram = "24Gi"
+	}
+
+	arch := os.Getenv("GPU_ARCH")
+	if arch == "" {
+		arch = "sm_89"
+	}
+
+	int4 := os.Getenv("GPU_INT4")
+	if int4 == "" {
+		int4 = "true"
+	}
+
+	labels[a.labelPrefix+"gpu.vendor"] = vendor
+	labels[a.labelPrefix+"gpu.vram"] = vram
+	labels[a.labelPrefix+"gpu.arch"] = arch
+	labels[a.labelPrefix+"gpu.int4"] = int4
 }
 
 // detectCPU populates the label map with CPU-related features.
 func (a *Agent) detectCPU(labels map[string]string) {
-	// Placeholder: In a real implementation, this would inspect /proc/cpuinfo.
-	labels[a.labelPrefix+"cpu.avx512"] = "false"
+	avx := os.Getenv("CPU_AVX512")
+	if avx == "" {
+		avx = "false"
+	}
+	labels[a.labelPrefix+"cpu.avx512"] = avx
 }

--- a/agents/agent/agent_test.go
+++ b/agents/agent/agent_test.go
@@ -17,10 +17,35 @@ func TestDetectGPU(t *testing.T) {
 	assert.Equal(t, "true", labels["flexinfer.ai/gpu.int4"])
 }
 
+func TestDetectGPUEnvOverride(t *testing.T) {
+	t.Setenv("GPU_VENDOR", "AMD")
+	t.Setenv("GPU_VRAM", "16Gi")
+	t.Setenv("GPU_ARCH", "gfx90a")
+	t.Setenv("GPU_INT4", "false")
+
+	agent := &Agent{labelPrefix: "flexinfer.ai/"}
+	labels := make(map[string]string)
+	agent.detectGPU(labels)
+
+	assert.Equal(t, "AMD", labels["flexinfer.ai/gpu.vendor"])
+	assert.Equal(t, "16Gi", labels["flexinfer.ai/gpu.vram"])
+	assert.Equal(t, "gfx90a", labels["flexinfer.ai/gpu.arch"])
+	assert.Equal(t, "false", labels["flexinfer.ai/gpu.int4"])
+}
+
 func TestDetectCPU(t *testing.T) {
 	agent := &Agent{labelPrefix: "flexinfer.ai/"}
 	labels := make(map[string]string)
 	agent.detectCPU(labels)
 
 	assert.Equal(t, "false", labels["flexinfer.ai/cpu.avx512"])
+}
+
+func TestDetectCPUEnvOverride(t *testing.T) {
+	t.Setenv("CPU_AVX512", "true")
+	agent := &Agent{labelPrefix: "flexinfer.ai/"}
+	labels := make(map[string]string)
+	agent.detectCPU(labels)
+
+	assert.Equal(t, "true", labels["flexinfer.ai/cpu.avx512"])
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/flexinfer/flexinfer/internal/cache"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -17,8 +19,16 @@ import (
 )
 
 // Scheduler implements the scheduler extender logic.
+type objectCache interface {
+	GetNode(name string) (*corev1.Node, error)
+	GetConfigMap(namespace, name string) (*corev1.ConfigMap, error)
+}
+
 type Scheduler struct {
-	cache *cache.Cache
+	cache      objectCache
+	tpsWeight  float64
+	utilWeight float64
+	costWeight float64
 }
 
 // NewScheduler creates a new Scheduler.
@@ -35,7 +45,20 @@ func NewScheduler() (*Scheduler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
 	}
-	return &Scheduler{cache: cache.NewCache(clientset)}, nil
+	s := &Scheduler{cache: cache.NewCache(clientset)}
+	s.tpsWeight = parseWeight("SCHED_TPS_WEIGHT", 0.7)
+	s.utilWeight = parseWeight("SCHED_UTIL_WEIGHT", 0.2)
+	s.costWeight = parseWeight("SCHED_COST_WEIGHT", 0.1)
+	return s, nil
+}
+
+func parseWeight(env string, def float64) float64 {
+	if v := os.Getenv(env); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return def
 }
 
 // Filter is the handler for the /filter endpoint.
@@ -118,9 +141,22 @@ func (s *Scheduler) Score(w http.ResponseWriter, r *http.Request) {
 
 	scores := make([]extenderv1.HostPriority, len(*args.NodeNames))
 	for i, nodeName := range *args.NodeNames {
+		node, err := s.cache.GetNode(nodeName)
+		if err != nil {
+			log.Error(err, "failed to get node", "node", nodeName)
+			continue
+		}
+
+		utilStr := node.Annotations["flexinfer.ai/gpu.util"]
+		util, _ := strconv.ParseFloat(utilStr, 64)
+		costStr := node.Annotations["flexinfer.ai/cost"]
+		cost, _ := strconv.ParseFloat(costStr, 64)
+
+		score := tps*s.tpsWeight - util*s.utilWeight - cost*s.costWeight
+
 		scores[i] = extenderv1.HostPriority{
 			Host:  nodeName,
-			Score: int64(tps), // Using tps as the score for now
+			Score: int64(score),
 		}
 	}
 

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1,0 +1,104 @@
+package scheduler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	extenderv1 "k8s.io/kube-scheduler/extender/v1"
+)
+
+type fakeCache struct {
+	nodes      map[string]*corev1.Node
+	configMaps map[string]*corev1.ConfigMap
+}
+
+func (f *fakeCache) GetNode(name string) (*corev1.Node, error) {
+	if n, ok := f.nodes[name]; ok {
+		return n, nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (f *fakeCache) GetConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
+	key := namespace + "/" + name
+	if cm, ok := f.configMaps[key]; ok {
+		return cm, nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func TestScore(t *testing.T) {
+	cache := &fakeCache{
+		nodes: map[string]*corev1.Node{
+			"node1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					Annotations: map[string]string{
+						"flexinfer.ai/gpu.util": "50",
+						"flexinfer.ai/cost":     "5",
+					},
+				},
+			},
+			"node2": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+					Annotations: map[string]string{
+						"flexinfer.ai/gpu.util": "10",
+						"flexinfer.ai/cost":     "2",
+					},
+				},
+			},
+		},
+		configMaps: map[string]*corev1.ConfigMap{
+			"default/md-benchmark-results": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "md-benchmark-results",
+					Namespace: "default",
+				},
+				Data: map[string]string{"tokensPerSecond": "100"},
+			},
+		},
+	}
+
+	sched := &Scheduler{cache: cache, tpsWeight: 0.7, utilWeight: 0.2, costWeight: 0.1}
+
+	args := extenderv1.ExtenderArgs{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p",
+				Namespace: "default",
+				Labels:    map[string]string{"modeldeployment_cr": "md"},
+			},
+		},
+		NodeNames: &[]string{"node1", "node2"},
+	}
+
+	body, _ := json.Marshal(args)
+	req := httptest.NewRequest("POST", "/score", bytes.NewBuffer(body))
+	rr := httptest.NewRecorder()
+
+	sched.Score(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rr.Code)
+	}
+
+	var result []extenderv1.HostPriority
+	if err := json.Unmarshal(rr.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 results got %d", len(result))
+	}
+
+	if result[0].Host == result[1].Host {
+		t.Fatalf("hosts should differ")
+	}
+}


### PR DESCRIPTION
## Summary
- add environment variable overrides for GPU/CPU detection
- add corresponding unit tests
- allow scheduler weights via environment variables
- implement scoring formula using node annotations
- test scoring logic with fake cache

## Testing
- `go test ./...` *(fails: controller suite can't start without kubebuilder assets)*

------
https://chatgpt.com/codex/tasks/task_e_6874538ee1b8832287174e508693d7d6